### PR TITLE
space error

### DIFF
--- a/Game_of_life.py
+++ b/Game_of_life.py
@@ -22,15 +22,15 @@ def create_initial_grid(rows, cols):
 
 def print_grid(rows, cols, grid, generation):
     clear_console()
-    output_str = "   "
+    output_str = ""
     for row in range(rows):
         for col in range(cols):
             if grid[row][col] == 0:
-                output_str += "     "
+                output_str += "  "
             else:
-                output_str += "Y  "
-        output_str += "   \n\r   "
-    print(output_str, end="     ")
+                output_str += "Y "
+        output_str += "\n\r"
+    print(output_str, end="")
 
 
 def create_next_grid(rows, cols, grid, next_grid):


### PR DESCRIPTION
fixed spacing errors in the the output displayed in the console.
there were incoherent spacing between the output_str between the empty space and the Y representing the alive cells.
when going to the next line there was a space character that shifted the output of the lines resulting in a misaligned output.